### PR TITLE
Correction of Behavior for initial values for Swing Clock Widgets

### DIFF
--- a/atdl4j/src/org/atdl4j/ui/swing/widget/SwingJideClockWidget.java
+++ b/atdl4j/src/org/atdl4j/ui/swing/widget/SwingJideClockWidget.java
@@ -294,9 +294,9 @@ public class SwingJideClockWidget
 					( showMonthYear && aValue.getYear() != DatatypeConstants.FIELD_UNDEFINED ) ? aValue.getYear() : tempNow.getYear(), 
 					( showMonthYear && aValue.getMonth() != DatatypeConstants.FIELD_UNDEFINED ) ? aValue.getMonth() : tempNow.getMonthOfYear(), 
 					( showMonthYear && aValue.getDay() != DatatypeConstants.FIELD_UNDEFINED ) ? aValue.getDay() : tempNow.getDayOfMonth(), 
-					( showMonthYear && aValue.getHour() != DatatypeConstants.FIELD_UNDEFINED ) ? aValue.getHour() : 0,
-					( showMonthYear && aValue.getMinute() != DatatypeConstants.FIELD_UNDEFINED ) ? aValue.getMinute() : 0,
-					( showMonthYear && aValue.getSecond() != DatatypeConstants.FIELD_UNDEFINED ) ? aValue.getSecond(): 0, 
+					( showTime && aValue.getHour() != DatatypeConstants.FIELD_UNDEFINED ) ? aValue.getHour() : 0,
+					( showTime && aValue.getMinute() != DatatypeConstants.FIELD_UNDEFINED ) ? aValue.getMinute() : 0,
+					( showTime && aValue.getSecond() != DatatypeConstants.FIELD_UNDEFINED ) ? aValue.getSecond(): 0, 
 					0,
 					tempLocalMktTz );
 			


### PR DESCRIPTION
Corrected Behavior for ATDL Swing Clock Widgets while parsing FIX messages.
