### PR TITLE
fixed redraw issue in Swing

### DIFF
--- a/src/main/java/org/atdl4j/ui/swing/app/impl/SwingAtdl4jCompositePanel.java
+++ b/src/main/java/org/atdl4j/ui/swing/app/impl/SwingAtdl4jCompositePanel.java
@@ -68,6 +68,7 @@ public class SwingAtdl4jCompositePanel
 			public void run() {
 				if (strPanel != null) {
 					strPanel.revalidate();
+					strPanel.repaint();
 				}
 				if (parentComposite != null) {
 					parentComposite.pack();


### PR DESCRIPTION
when you set the panel to a fixed size and change strategies using the
keyboard - this results in the strategy panel not properly drawing due
to layout changes
